### PR TITLE
Update Gui to use property name scale_body

### DIFF
--- a/Gui/opensim/rice_cnl/src/org/opensim/rcnl/AddEditJMPBodyPanel.java
+++ b/Gui/opensim/rice_cnl/src/org/opensim/rcnl/AddEditJMPBodyPanel.java
@@ -53,7 +53,7 @@ public class AddEditJMPBodyPanel extends javax.swing.JPanel {
         initComponents();
         jComboBoxBodies.setModel(cbm);
 
-        toScaleProp = jmpBodyTask.getPropertyByName("scale_bodies");
+        toScaleProp = jmpBodyTask.getPropertyByName("scale_body");
         scale_bod = PropertyBoolList.getAs(toScaleProp).getValue(0);
         
         moveMarkersProp = jmpBodyTask.getPropertyByName("move_markers");


### PR DESCRIPTION
Fixes issue #6 

### Brief summary of changes
Change the plugin to use property name scale_body and update GUI code base to match.

### Testing I've completed
 Tested by save/restore and by inspecting the properties in the XML Browser.
### CHANGELOG.md (choose one)

- no need to update because not publicly available yet
