### PR TITLE
Save relative paths to xml

### DIFF
--- a/Gui/opensim/rice_cnl/src/org/opensim/rcnl/BaseToolPanel.java
+++ b/Gui/opensim/rice_cnl/src/org/opensim/rcnl/BaseToolPanel.java
@@ -145,7 +145,7 @@ public abstract class BaseToolPanel extends JPanel implements ActionListener, Ob
             for (int i = 0; i < nodeList.getLength(); i++) {
                 Node oldNode = nodeList.item(i);
                 Element element = (Element) oldNode; 
-                if (element != null) { element.setAttribute("Version", "1.5.0"); }
+                if (element != null) { element.setAttribute("Version", "1.5.2"); }
                 doc.renameNode(oldNode, oldNode.getNamespaceURI(), "NMSMPipelineDocument");
             }
             TransformerFactory transformerFactory = TransformerFactory.newInstance();

--- a/Gui/opensim/rice_cnl/src/org/opensim/rcnl/BaseToolPanel.java
+++ b/Gui/opensim/rice_cnl/src/org/opensim/rcnl/BaseToolPanel.java
@@ -43,7 +43,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
 import java.util.Observer;
 import javax.swing.AbstractAction;
 import javax.swing.JButton;
@@ -59,18 +59,21 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+import java.net.URL;
 import org.openide.DialogDescriptor;
 import org.openide.DialogDisplayer;
 import org.openide.util.Exceptions;
 import org.opensim.modeling.OpenSimObject;
 import org.opensim.utils.FileUtils;
 import org.opensim.view.pub.OpenSimDB;
+import org.opensim.utils.BrowserLauncher;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+
 
 public abstract class BaseToolPanel extends JPanel implements ActionListener, Observer {
 
@@ -199,10 +202,29 @@ public abstract class BaseToolPanel extends JPanel implements ActionListener, Ob
         }
     }
 
+    class HelpAction extends AbstractAction {
+
+        public HelpAction() {
+            super("Help");
+        }
+
+        public void actionPerformed(ActionEvent evt) {
+            goToHelpURL();
+        }
+    }
+
+    // helpButton.addActionListener(new ActionListener() {
+    //   public void actionPerformed(ActionEvent ae) {
+    //       String path = "https://simtk-confluence.stanford.edu/display/OpenSim40/" + helpUrl;
+    //       BrowserLauncher.openURL(path);
+    //   }
+    //   });
+
     public BaseToolPanel() {
 
         loadSettingsButton.addActionListener(new LoadSettingsAction());
         saveSettingsButton.addActionListener(new SaveSettingsAction());
+        helpButton.addActionListener(new HelpAction());
         applyButton.setEnabled(false);
         OpenSimDB.getInstance().addObserver(this);
     }
@@ -219,6 +241,8 @@ public abstract class BaseToolPanel extends JPanel implements ActionListener, Ob
     }
 
     abstract void saveSettings(String fileName) ;
+
+    abstract void goToHelpURL();
 
     public void pressedCancel() {
     }

--- a/Gui/opensim/rice_cnl/src/org/opensim/rcnl/ConstraintTermModel.java
+++ b/Gui/opensim/rice_cnl/src/org/opensim/rcnl/ConstraintTermModel.java
@@ -60,8 +60,8 @@ public class ConstraintTermModel {
                 return PropertyStringList.updAs(constraintTerm.updPropertyByName("moment_list"));
             case "muscle":
                 return PropertyStringList.updAs(constraintTerm.updPropertyByName("muscle_list"));
-            case "synergy_group":
-                return PropertyStringList.updAs(constraintTerm.updPropertyByName("synergy_group_list"));
+            case "synergy":
+                return PropertyStringList.updAs(constraintTerm.updPropertyByName("synergy_list"));
             case "marker":
                 return PropertyStringList.updAs(constraintTerm.updPropertyByName("marker_list"));
             case "body":

--- a/Gui/opensim/rice_cnl/src/org/opensim/rcnl/CostTermModel.java
+++ b/Gui/opensim/rice_cnl/src/org/opensim/rcnl/CostTermModel.java
@@ -60,6 +60,8 @@ public class CostTermModel {
                 return PropertyStringList.updAs(costTerm.updPropertyByName("force_list"));
             case "muscle":
                 return PropertyStringList.updAs(costTerm.updPropertyByName("muscle_list"));
+            case "synergy":
+                return PropertyStringList.updAs(costTerm.updPropertyByName("synergy_list"));
             case "moment":
                 return PropertyStringList.updAs(costTerm.updPropertyByName("moment_list"));
             case "controller":

--- a/Gui/opensim/rice_cnl/src/org/opensim/rcnl/GCPPersonalizationJPanel.form
+++ b/Gui/opensim/rice_cnl/src/org/opensim/rcnl/GCPPersonalizationJPanel.form
@@ -21,7 +21,7 @@
               <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="inputModelPanel" alignment="0" max="32767" attributes="0"/>
                   <Component id="settingsPanel" alignment="1" max="32767" attributes="0"/>
-                  <Component id="outputPanel" alignment="0" pref="755" max="32767" attributes="2"/>
+                  <Component id="outputPanel" alignment="0" max="32767" attributes="2"/>
               </Group>
           </Group>
       </Group>
@@ -60,17 +60,15 @@
               <Group type="102" alignment="0" attributes="0">
                   <EmptySpace min="-2" pref="20" max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="jLabel13" alignment="0" min="-2" max="-2" attributes="0"/>
-                      <Component id="jLabel3" alignment="0" min="-2" max="-2" attributes="0"/>
-                      <Component id="jLabel4" alignment="0" min="-2" max="-2" attributes="0"/>
-                      <Component id="jLabel2" min="-2" max="-2" attributes="0"/>
-                      <Component id="jLabel5" min="-2" max="-2" attributes="0"/>
+                      <Component id="jLabel2" min="-2" pref="68" max="-2" attributes="0"/>
+                      <Component id="jLabel3" min="-2" max="-2" attributes="0"/>
+                      <Component id="jLabel5" min="-2" pref="118" max="-2" attributes="0"/>
+                      <Component id="jLabel13" min="-2" pref="68" max="-2" attributes="0"/>
                   </Group>
                   <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="osimxFilePath" pref="491" max="32767" attributes="3"/>
+                      <Component id="osimxFilePath" pref="599" max="32767" attributes="3"/>
                       <Component id="currentModelFileTextField" max="32767" attributes="1"/>
-                      <Component id="inputDirPath" alignment="0" max="32767" attributes="3"/>
                       <Component id="motionFilePath" alignment="0" max="32767" attributes="3"/>
                       <Component id="grfFilePath" alignment="1" max="32767" attributes="3"/>
                   </Group>
@@ -81,33 +79,29 @@
         <DimensionLayout dim="1">
           <Group type="103" groupAlignment="0" attributes="0">
               <Group type="102" alignment="0" attributes="0">
-                  <Group type="103" groupAlignment="3" attributes="0">
-                      <Component id="jLabel13" alignment="3" min="-2" max="-2" attributes="0"/>
-                      <Component id="currentModelFileTextField" alignment="3" min="-2" max="-2" attributes="0"/>
-                  </Group>
-                  <EmptySpace type="unrelated" max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="osimxFilePath" min="-2" max="-2" attributes="0"/>
-                      <Component id="jLabel3" min="-2" max="-2" attributes="0"/>
-                  </Group>
-                  <EmptySpace type="unrelated" max="-2" attributes="0"/>
-                  <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="inputDirPath" min="-2" max="-2" attributes="0"/>
-                      <Component id="jLabel4" min="-2" max="-2" attributes="0"/>
-                  </Group>
-                  <EmptySpace type="unrelated" max="-2" attributes="0"/>
-                  <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="motionFilePath" min="-2" max="-2" attributes="0"/>
-                      <Component id="jLabel2" min="-2" max="-2" attributes="0"/>
-                  </Group>
-                  <EmptySpace max="32767" attributes="0"/>
-                  <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="grfFilePath" alignment="1" min="-2" max="-2" attributes="0"/>
-                      <Group type="102" alignment="1" attributes="0">
-                          <Component id="jLabel5" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace max="-2" attributes="0"/>
+                      <Component id="currentModelFileTextField" min="-2" max="-2" attributes="0"/>
+                      <Group type="102" attributes="0">
+                          <EmptySpace min="3" pref="3" max="-2" attributes="0"/>
+                          <Component id="jLabel13" min="-2" pref="21" max="-2" attributes="0"/>
                       </Group>
                   </Group>
+                  <EmptySpace type="separate" max="-2" attributes="0"/>
+                  <Group type="103" groupAlignment="0" max="-2" attributes="0">
+                      <Component id="osimxFilePath" max="32767" attributes="0"/>
+                      <Component id="jLabel3" max="32767" attributes="0"/>
+                  </Group>
+                  <EmptySpace type="separate" max="-2" attributes="0"/>
+                  <Group type="103" groupAlignment="0" max="-2" attributes="0">
+                      <Component id="motionFilePath" max="32767" attributes="0"/>
+                      <Component id="jLabel2" max="32767" attributes="0"/>
+                  </Group>
+                  <EmptySpace type="separate" max="-2" attributes="0"/>
+                  <Group type="103" groupAlignment="0" max="-2" attributes="0">
+                      <Component id="grfFilePath" max="32767" attributes="0"/>
+                      <Component id="jLabel5" max="32767" attributes="0"/>
+                  </Group>
+                  <EmptySpace pref="8" max="32767" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>
@@ -140,18 +134,6 @@
           <Properties>
             <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
               <ResourceString bundle="org/opensim/rcnl/Bundle.properties" key="GCPPersonalizationJPanel.jLabel3.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
-            </Property>
-          </Properties>
-        </Component>
-        <Component class="org.opensim.swingui.FileTextFieldAndChooser" name="inputDirPath">
-          <Events>
-            <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="inputDirPathStateChanged"/>
-          </Events>
-        </Component>
-        <Component class="javax.swing.JLabel" name="jLabel4">
-          <Properties>
-            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-              <ResourceString bundle="org/opensim/rcnl/Bundle.properties" key="GCPPersonalizationJPanel.jLabel4.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
             </Property>
           </Properties>
         </Component>

--- a/Gui/opensim/rice_cnl/src/org/opensim/rcnl/GCPPersonalizationJPanel.java
+++ b/Gui/opensim/rice_cnl/src/org/opensim/rcnl/GCPPersonalizationJPanel.java
@@ -443,7 +443,7 @@ public class GCPPersonalizationJPanel extends BaseToolPanel  implements Observer
         String inputMotionFileName = gcpPersonalizationToolModel.getInputMotionFile();
         String inputGrfFileName = gcpPersonalizationToolModel.geInputGRFFile();
         String osimxFileName = gcpPersonalizationToolModel.getInputOsimxFile();
-        String inputModelFileName = gcpPersonalizationToolModel.getInputModelFile();
+        // String inputModelFileName = gcpPersonalizationToolModel.getInputModelFile();
         String resultsDirectory = gcpPersonalizationToolModel.getOutputResultDir();
 
         Path inputMotionAbsolutePath = Paths.get(inputMotionFileName).getParent();

--- a/Gui/opensim/rice_cnl/src/org/opensim/rcnl/GCPPersonalizationJPanel.java
+++ b/Gui/opensim/rice_cnl/src/org/opensim/rcnl/GCPPersonalizationJPanel.java
@@ -28,6 +28,7 @@ import org.opensim.modeling.PropertyObjectList;
 import org.opensim.modeling.Storage;
 import org.opensim.utils.FileUtils;
 import org.opensim.view.pub.OpenSimDB;
+import org.opensim.utils.BrowserLauncher;
 
 /**
  *
@@ -480,6 +481,11 @@ public class GCPPersonalizationJPanel extends BaseToolPanel  implements Observer
         gcpPersonalizationToolModel.setInputGRFFile(inputGrfFileName);
         gcpPersonalizationToolModel.setInputOsimxFile(osimxFileName);
         gcpPersonalizationToolModel.setOutputResultDir(resultsDirectory);
+    }
+
+    @Override
+    public void goToHelpURL() {
+        BrowserLauncher.openURL("https://nmsm.rice.edu/model-personalization/ground-contact-personalization/intro/");
     }
 
 

--- a/Gui/opensim/rice_cnl/src/org/opensim/rcnl/GCPPersonalizationJPanel.java
+++ b/Gui/opensim/rice_cnl/src/org/opensim/rcnl/GCPPersonalizationJPanel.java
@@ -9,9 +9,12 @@ import java.awt.Dialog;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Observable;
 import java.util.Observer;
 import java.util.Vector;
+import java.io.File;
 import javax.swing.ListSelectionModel;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
@@ -59,9 +62,6 @@ public class GCPPersonalizationJPanel extends BaseToolPanel  implements Observer
        osimxFilePath.setDialogTitle("Select osimx file");
        osimxFilePath.setDirectoriesOnly(false);
        osimxFilePath.setExtensionsAndDescription(".osimx", "File to contain pipeline specific entities");
-       inputDirPath.setDialogTitle("Select input data directory");
-       inputDirPath.setDirectoriesOnly(true);
-       inputDirPath.setCheckIfFileExists(true);
        motionFilePath.setDialogTitle("Select input motion file");
        motionFilePath.setDirectoriesOnly(false);
        motionFilePath.setCheckIfFileExists(true);
@@ -91,8 +91,6 @@ public class GCPPersonalizationJPanel extends BaseToolPanel  implements Observer
         currentModelFileTextField = new javax.swing.JTextField();
         osimxFilePath = new org.opensim.swingui.FileTextFieldAndChooser();
         jLabel3 = new javax.swing.JLabel();
-        inputDirPath = new org.opensim.swingui.FileTextFieldAndChooser();
-        jLabel4 = new javax.swing.JLabel();
         motionFilePath = new org.opensim.swingui.FileTextFieldAndChooser();
         jLabel2 = new javax.swing.JLabel();
         grfFilePath = new org.opensim.swingui.FileTextFieldAndChooser();
@@ -124,14 +122,6 @@ public class GCPPersonalizationJPanel extends BaseToolPanel  implements Observer
 
         org.openide.awt.Mnemonics.setLocalizedText(jLabel3, org.openide.util.NbBundle.getMessage(GCPPersonalizationJPanel.class, "GCPPersonalizationJPanel.jLabel3.text")); // NOI18N
 
-        inputDirPath.addChangeListener(new javax.swing.event.ChangeListener() {
-            public void stateChanged(javax.swing.event.ChangeEvent evt) {
-                inputDirPathStateChanged(evt);
-            }
-        });
-
-        org.openide.awt.Mnemonics.setLocalizedText(jLabel4, org.openide.util.NbBundle.getMessage(GCPPersonalizationJPanel.class, "GCPPersonalizationJPanel.jLabel4.text")); // NOI18N
-
         motionFilePath.addChangeListener(new javax.swing.event.ChangeListener() {
             public void stateChanged(javax.swing.event.ChangeEvent evt) {
                 motionFilePathStateChanged(evt);
@@ -155,16 +145,14 @@ public class GCPPersonalizationJPanel extends BaseToolPanel  implements Observer
             .addGroup(inputModelPanelLayout.createSequentialGroup()
                 .addGap(20, 20, 20)
                 .addGroup(inputModelPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(jLabel13)
+                    .addComponent(jLabel2, javax.swing.GroupLayout.PREFERRED_SIZE, 68, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(jLabel3)
-                    .addComponent(jLabel4)
-                    .addComponent(jLabel2)
-                    .addComponent(jLabel5))
+                    .addComponent(jLabel5, javax.swing.GroupLayout.PREFERRED_SIZE, 118, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel13, javax.swing.GroupLayout.PREFERRED_SIZE, 68, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(inputModelPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(osimxFilePath, javax.swing.GroupLayout.DEFAULT_SIZE, 491, Short.MAX_VALUE)
+                    .addComponent(osimxFilePath, javax.swing.GroupLayout.DEFAULT_SIZE, 599, Short.MAX_VALUE)
                     .addComponent(currentModelFileTextField, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addComponent(inputDirPath, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addComponent(motionFilePath, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addComponent(grfFilePath, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                 .addGap(0, 0, 0))
@@ -172,27 +160,24 @@ public class GCPPersonalizationJPanel extends BaseToolPanel  implements Observer
         inputModelPanelLayout.setVerticalGroup(
             inputModelPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(inputModelPanelLayout.createSequentialGroup()
-                .addGroup(inputModelPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(jLabel13)
-                    .addComponent(currentModelFileTextField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addGroup(inputModelPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(osimxFilePath, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jLabel3))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                .addGroup(inputModelPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(inputDirPath, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jLabel4))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                .addGroup(inputModelPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(motionFilePath, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jLabel2))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                .addGroup(inputModelPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(grfFilePath, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, inputModelPanelLayout.createSequentialGroup()
-                        .addComponent(jLabel5)
-                        .addContainerGap())))
+                    .addComponent(currentModelFileTextField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addGroup(inputModelPanelLayout.createSequentialGroup()
+                        .addGap(3, 3, 3)
+                        .addComponent(jLabel13, javax.swing.GroupLayout.PREFERRED_SIZE, 21, javax.swing.GroupLayout.PREFERRED_SIZE)))
+                .addGap(18, 18, 18)
+                .addGroup(inputModelPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                    .addComponent(osimxFilePath, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(jLabel3, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                .addGap(18, 18, 18)
+                .addGroup(inputModelPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                    .addComponent(motionFilePath, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(jLabel2, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                .addGap(18, 18, 18)
+                .addGroup(inputModelPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                    .addComponent(grfFilePath, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(jLabel5, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                .addContainerGap(8, Short.MAX_VALUE))
         );
 
         outputPanel.setBorder(javax.swing.BorderFactory.createTitledBorder(javax.swing.BorderFactory.createEtchedBorder(), org.openide.util.NbBundle.getMessage(GCPPersonalizationJPanel.class, "GCPPersonalizationJPanel.outputPanel.border.title"))); // NOI18N
@@ -308,7 +293,7 @@ public class GCPPersonalizationJPanel extends BaseToolPanel  implements Observer
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(inputModelPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addComponent(settingsPanel, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addComponent(outputPanel, javax.swing.GroupLayout.PREFERRED_SIZE, 0, Short.MAX_VALUE)))
+                    .addComponent(outputPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)))
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -331,11 +316,6 @@ public class GCPPersonalizationJPanel extends BaseToolPanel  implements Observer
         // TODO add your handling code here:
         gcpPersonalizationToolModel.setInputOsimxFile(osimxFilePath.getFileName());
     }//GEN-LAST:event_osimxFilePathStateChanged
-
-    private void inputDirPathStateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_inputDirPathStateChanged
-        // TODO add your handling code here:
-        gcpPersonalizationToolModel.setDataDir(inputDirPath.getFileName());
-    }//GEN-LAST:event_inputDirPathStateChanged
 
     private void motionFilePathStateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_motionFilePathStateChanged
         // TODO add your handling code here:

--- a/Gui/opensim/rice_cnl/src/org/opensim/rcnl/GCPPersonalizationJPanel.java
+++ b/Gui/opensim/rice_cnl/src/org/opensim/rcnl/GCPPersonalizationJPanel.java
@@ -485,7 +485,7 @@ public class GCPPersonalizationJPanel extends BaseToolPanel  implements Observer
 
     @Override
     public void goToHelpURL() {
-        BrowserLauncher.openURL("https://nmsm.rice.edu/model-personalization/ground-contact-personalization/intro/");
+        BrowserLauncher.openURL("https://nmsm.rice.edu/guides-and-publications/tool-overviews/model-personalization/ground-contact-personalization/");
     }
 
 

--- a/Gui/opensim/rice_cnl/src/org/opensim/rcnl/JointPersonalizationJPanel.java
+++ b/Gui/opensim/rice_cnl/src/org/opensim/rcnl/JointPersonalizationJPanel.java
@@ -28,6 +28,7 @@ import org.opensim.modeling.PropertyHelper;
 import org.opensim.modeling.PropertyObjectList;
 import org.opensim.utils.FileUtils;
 import org.opensim.view.pub.OpenSimDB;
+import org.opensim.utils.BrowserLauncher;
 
 /**
  *
@@ -315,11 +316,22 @@ public class JointPersonalizationJPanel extends BaseToolPanel  implements Observ
         String settingsFilePath = Paths.get(fileName).getParent().toString();
 
         String outputModelFileName = jointPersonalizationToolModel.getOutputModelFile();
-
         Path outputModelFileNamePath = Paths.get(outputModelFileName);
         String relativeOutputModelFileName = FileUtils.makePathRelative(outputModelFileName, settingsFilePath);
         if (relativeOutputModelFileName != null && outputModelFileNamePath != null && outputModelFileNamePath.isAbsolute()){
-            jointPersonalizationToolModel.setOutputModelFile(outputModelFileName);
+            jointPersonalizationToolModel.setOutputModelFile(relativeOutputModelFileName);
+        }
+        
+        PropertyObjectList taskList = jointPersonalizationToolModel.getJointTaskListAsObjectList();
+        for (int i=0; i<taskList.size(); i++){
+            OpenSimObject task = taskList.getValue(i);
+            AbstractProperty markerFileProperty = task.getPropertyByName("marker_file_name");
+            String markerFileName = markerFileProperty.toString();
+            Path markerFilePath = Paths.get(markerFileName);
+            String relativeMarkerFileName = FileUtils.makePathRelative(markerFileName, settingsFilePath);
+            if (relativeMarkerFileName != null && markerFilePath != null && markerFilePath.isAbsolute()){
+                PropertyHelper.setValueString(relativeMarkerFileName, markerFileProperty);
+            }
         }
 
         String fullFilename = FileUtils.addExtensionIfNeeded(fileName, ".xml");
@@ -328,7 +340,15 @@ public class JointPersonalizationJPanel extends BaseToolPanel  implements Observ
         obj.print(fullFilename);
         replaceOpenSimDocumentTags(fullFilename);
         
-        // jointPersonalizationToolModel.setOutputModelFile(outputModelFileName);
+        jointPersonalizationToolModel.setOutputModelFile(outputModelFileName);
+        
+        for (int i=0; i<taskList.size(); i++){
+            OpenSimObject task = taskList.getValue(i);
+            AbstractProperty markerFileProperty = task.getPropertyByName("marker_file_name");
+            String markerFileName = markerFileProperty.toString();
+            String absoluteMarkerFileName = FileUtils.makePathAbsolute(markerFileName, settingsFilePath);
+            PropertyHelper.setValueString(absoluteMarkerFileName, markerFileProperty);
+        }
     }
 
     @Override
@@ -342,16 +362,33 @@ public class JointPersonalizationJPanel extends BaseToolPanel  implements Observ
         String outputModelFile = jointPersonalizationToolModel.getOutputModelFile();
         String absoluteOutputModelFile = FileUtils.makePathAbsolute(outputModelFile, settingsFilePath);
         outputModelFilePath.setFileName(absoluteOutputModelFile);
+        
+
+        PropertyObjectList taskList = jointPersonalizationToolModel.getJointTaskListAsObjectList();
+        for (int i=0; i<taskList.size(); i++){
+            OpenSimObject task = taskList.getValue(i);
+            AbstractProperty markerFileProperty = task.getPropertyByName("marker_file_name");
+            String markerFileName = markerFileProperty.toString();
+            String absoluteMarkerFileName = FileUtils.makePathAbsolute(markerFileName, settingsFilePath);
+            PropertyHelper.setValueString(absoluteMarkerFileName, markerFileProperty);
+        }
+
 
         File f= new File(fileName); 
         f.delete();
         jointPersonalizationTaskListModel = new JMPTaskListModel(jointPersonalizationToolModel.getJointTaskListAsObjectList());
         listSelectionModel = jJointPersonalizationList.getSelectionModel();
         listSelectionModel.addListSelectionListener( new ListSelectionHandler());
+        
         //initComponents(); Panel already constructed, no need to re-initComponents
         jJointPersonalizationList.setModel(jointPersonalizationTaskListModel);
         currentModelFileTextField.setText(jointPersonalizationToolModel.getInputModelFile());
         setSettingsFileDescription("Save Joint Personalization Settings file (xml)");
+    }
+
+    @Override
+    public void goToHelpURL() {
+        BrowserLauncher.openURL("https://nmsm.rice.edu/model-personalization/joint-model-personalization/");
     }
 
     @Override
@@ -427,6 +464,7 @@ public class JointPersonalizationJPanel extends BaseToolPanel  implements Observ
     private org.opensim.swingui.FileTextFieldAndChooser outputModelFilePath;
     private javax.swing.JPanel outputPanel;
     private javax.swing.JPanel tasksPanel;
+    
     // End of variables declaration//GEN-END:variables
 
     private class ListSelectionHandler implements ListSelectionListener {

--- a/Gui/opensim/rice_cnl/src/org/opensim/rcnl/JointPersonalizationJPanel.java
+++ b/Gui/opensim/rice_cnl/src/org/opensim/rcnl/JointPersonalizationJPanel.java
@@ -387,11 +387,6 @@ public class JointPersonalizationJPanel extends BaseToolPanel  implements Observ
     }
 
     @Override
-    public void goToHelpURL() {
-        BrowserLauncher.openURL("https://nmsm.rice.edu/model-personalization/joint-model-personalization/");
-    }
-
-    @Override
     public void setSettingsFileDescription(String description) {
         super.setSettingsFileDescription(description); //To change body of generated methods, choose Tools | Templates.
     }
@@ -448,6 +443,11 @@ public class JointPersonalizationJPanel extends BaseToolPanel  implements Observ
             retValue = Math.max(nextTaskIndex+1, retValue);
         }
         return retValue;
+    }
+
+    @Override
+    public void goToHelpURL() {
+        BrowserLauncher.openURL("https://nmsm.rice.edu/guides-and-publications/tool-overviews/model-personalization/joint-model-personalization/");
     }
 
     // Variables declaration - do not modify//GEN-BEGIN:variables

--- a/Gui/opensim/rice_cnl/src/org/opensim/rcnl/MTPPersonalizationJPanel.java
+++ b/Gui/opensim/rice_cnl/src/org/opensim/rcnl/MTPPersonalizationJPanel.java
@@ -26,6 +26,7 @@ import org.opensim.modeling.OpenSimObject;
 import org.opensim.modeling.PropertyObjectList;
 import org.opensim.utils.FileUtils;
 import org.opensim.view.pub.OpenSimDB;
+import org.opensim.utils.BrowserLauncher;
 
 /**
  *
@@ -667,6 +668,11 @@ public class MTPPersonalizationJPanel extends BaseToolPanel  implements Observer
         jCheckBoxMTPInitialization.setSelected(mtpPersonalizationToolModel.getEnableInitialization());
         jCheckBoxSynergyExrapolate.setSelected(mtpPersonalizationToolModel.getEnableSynergies());
         jSpinnerSunergyCount.setValue(mtpPersonalizationToolModel.getNumSynergies());
+    }
+
+    @Override
+    public void goToHelpURL() {
+        BrowserLauncher.openURL("https://nmsm.rice.edu/model-personalization/muscle-tendon-personalization/");
     }
 
     @Override

--- a/Gui/opensim/rice_cnl/src/org/opensim/rcnl/MTPPersonalizationJPanel.java
+++ b/Gui/opensim/rice_cnl/src/org/opensim/rcnl/MTPPersonalizationJPanel.java
@@ -9,6 +9,8 @@ import java.awt.Dialog;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Observable;
 import java.util.Observer;
 import java.util.Vector;
@@ -634,22 +636,37 @@ public class MTPPersonalizationJPanel extends BaseToolPanel  implements Observer
     @Override
     public void loadSettings(String nmsmFilename) {
         String fileName = BaseToolPanel.stripOuterTags(nmsmFilename);
+        String settingsFilePath = Paths.get(fileName).getParent().toString();
         Model model = OpenSimDB.getInstance().getCurrentModel();
-       //if(model==null) throw new IOException("JointPersonalizationJPanel got null model");
-       mtpPersonalizationToolModel = new MTPPersonalizationToolModel(model, fileName);
-       osimxFilePath.setFileName(mtpPersonalizationToolModel.getInputOsimxFile());
-       dataDirPath.setFileName(mtpPersonalizationToolModel.getDataDir());
-       outputResultDirPath.setFileName(mtpPersonalizationToolModel.getOutputResultDir());
-       jCoordinateListTextArea.setText(mtpPersonalizationToolModel.getPropCoordinateListString().toString());
-       jActivationMGTextArea.setText(mtpPersonalizationToolModel.getPropActivationMGListString().toString());
-       jNormalizedFLMGTextArea.setText(mtpPersonalizationToolModel.getPropNormalizedFLMGListString().toString());
-       jMissingEMGTextArea.setText(mtpPersonalizationToolModel.getPropMissingEMGMGListString().toString());
-       jCollectedEMGTextArea.setText(mtpPersonalizationToolModel.getPropCollectedEMGMGListString().toString());
-       passiveDataInputDir.setFileName(mtpPersonalizationToolModel.getPassiveDataDir());
-       setSettingsFileDescription("Save Muscle Tendon Personalization Settings file (xml)");
-       jCheckBoxMTPInitialization.setSelected(mtpPersonalizationToolModel.getEnableInitialization());
-       jCheckBoxSynergyExrapolate.setSelected(mtpPersonalizationToolModel.getEnableSynergies());
-       jSpinnerSunergyCount.setValue(mtpPersonalizationToolModel.getNumSynergies());
+        mtpPersonalizationToolModel = new MTPPersonalizationToolModel(model, fileName);
+
+        String resultsDirectory = mtpPersonalizationToolModel.getOutputResultDir();
+        String absoluteResultsDirectory = FileUtils.makePathAbsolute(resultsDirectory, settingsFilePath);
+        outputResultDirPath.setFileName(absoluteResultsDirectory);
+
+        String inputOsimxFile = mtpPersonalizationToolModel.getInputOsimxFile();
+        String absoluteInputOsimxFile = FileUtils.makePathAbsolute(inputOsimxFile, settingsFilePath);
+        osimxFilePath.setFileName(absoluteInputOsimxFile);
+
+        String inputDataDirectory = mtpPersonalizationToolModel.getDataDir();
+        String absoluteInputDataDirectory = FileUtils.makePathAbsolute(inputDataDirectory, settingsFilePath);
+        dataDirPath.setFileName(absoluteInputDataDirectory);
+
+        String passiveDataDirectory = mtpPersonalizationToolModel.getPassiveDataDir();
+        String absolutePassiveDataDirectory = FileUtils.makePathAbsolute(passiveDataDirectory, settingsFilePath);
+        passiveDataInputDir.setFileName(absolutePassiveDataDirectory);
+        
+        //if(model==null) throw new IOException("JointPersonalizationJPanel got null model");
+        
+        jCoordinateListTextArea.setText(mtpPersonalizationToolModel.getPropCoordinateListString().toString());
+        jActivationMGTextArea.setText(mtpPersonalizationToolModel.getPropActivationMGListString().toString());
+        jNormalizedFLMGTextArea.setText(mtpPersonalizationToolModel.getPropNormalizedFLMGListString().toString());
+        jMissingEMGTextArea.setText(mtpPersonalizationToolModel.getPropMissingEMGMGListString().toString());
+        jCollectedEMGTextArea.setText(mtpPersonalizationToolModel.getPropCollectedEMGMGListString().toString());
+        setSettingsFileDescription("Save Muscle Tendon Personalization Settings file (xml)");
+        jCheckBoxMTPInitialization.setSelected(mtpPersonalizationToolModel.getEnableInitialization());
+        jCheckBoxSynergyExrapolate.setSelected(mtpPersonalizationToolModel.getEnableSynergies());
+        jSpinnerSunergyCount.setValue(mtpPersonalizationToolModel.getNumSynergies());
     }
 
     @Override
@@ -702,11 +719,57 @@ public class MTPPersonalizationJPanel extends BaseToolPanel  implements Observer
 
     @Override
     public void saveSettings(String fileName) {
+        String settingsFilePath = Paths.get(fileName).getParent().toString();
+
+        String resultsDirectory = mtpPersonalizationToolModel.getOutputResultDir();
+        String inputOsimxFile = mtpPersonalizationToolModel.getInputOsimxFile();
+        String inputDataDirectory = mtpPersonalizationToolModel.getDataDir();
+        String passiveDataDirectory = mtpPersonalizationToolModel.getPassiveDataDir();
+        Model model = OpenSimDB.getInstance().getCurrentModel();
+        String inputModelFileName = model.getInputFileName();
+
+        // Make paths relative to settings file
+        Path resultsDirectoryPath = Paths.get(resultsDirectory);
+        String relativeResultsDir = FileUtils.makePathRelative(resultsDirectory, settingsFilePath);
+        if (relativeResultsDir != null && resultsDirectoryPath!=null && resultsDirectoryPath.isAbsolute()){
+            mtpPersonalizationToolModel.setOutputResultDir(relativeResultsDir);
+        }
+
+        Path inputOsimxFilePath = Paths.get(inputOsimxFile);
+        String relativeInputOsimxFile = FileUtils.makePathRelative(inputOsimxFile, settingsFilePath);
+        if (relativeInputOsimxFile != null && inputOsimxFilePath!=null && inputOsimxFilePath.isAbsolute()){
+            mtpPersonalizationToolModel.setInputOsimxFile(relativeInputOsimxFile);
+        }
+
+        Path inputDataDirectoryPath = Paths.get(inputDataDirectory);
+        String relativeInputDataDirectory = FileUtils.makePathRelative(inputDataDirectory, settingsFilePath);
+        if (relativeInputDataDirectory != null && inputDataDirectoryPath!=null && inputDataDirectoryPath.isAbsolute()){
+            mtpPersonalizationToolModel.setDataDir(relativeInputDataDirectory);
+        }
+
+        Path passiveDataDirectoryPath = Paths.get(passiveDataDirectory);
+        String relativePassiveDataDirectory = FileUtils.makePathRelative(passiveDataDirectory, settingsFilePath);
+        if (relativePassiveDataDirectory != null && passiveDataDirectoryPath!=null && passiveDataDirectoryPath.isAbsolute()){
+            mtpPersonalizationToolModel.setPassiveDataDir(relativePassiveDataDirectory);
+        }
+
+        Path inputModelFilePath = Paths.get(inputModelFileName);
+        String relativeInputModelFile = FileUtils.makePathRelative(inputModelFileName, settingsFilePath);
+        if (relativeInputModelFile != null && inputModelFilePath!=null && inputModelFilePath.isAbsolute()){
+            mtpPersonalizationToolModel.setInputModelFile(relativeInputModelFile);
+        }
+
         String fullFilename = FileUtils.addExtensionIfNeeded(fileName, ".xml");
         OpenSimObject obj = mtpPersonalizationToolModel.getToolAsObject();
         forceWritableProperties(obj);
         obj.print(fullFilename);
         replaceOpenSimDocumentTags(fullFilename);
+
+        mtpPersonalizationToolModel.setOutputResultDir(resultsDirectory);
+        mtpPersonalizationToolModel.setInputOsimxFile(inputOsimxFile);
+        mtpPersonalizationToolModel.setDataDir(inputDataDirectory);
+        mtpPersonalizationToolModel.setPassiveDataDir(passiveDataDirectory);
+        mtpPersonalizationToolModel.setInputModelFile(inputModelFileName);
     }
 
     @Override

--- a/Gui/opensim/rice_cnl/src/org/opensim/rcnl/MTPPersonalizationJPanel.java
+++ b/Gui/opensim/rice_cnl/src/org/opensim/rcnl/MTPPersonalizationJPanel.java
@@ -672,7 +672,7 @@ public class MTPPersonalizationJPanel extends BaseToolPanel  implements Observer
 
     @Override
     public void goToHelpURL() {
-        BrowserLauncher.openURL("https://nmsm.rice.edu/model-personalization/muscle-tendon-personalization/");
+        BrowserLauncher.openURL("https://nmsm.rice.edu/guides-and-publications/tool-overviews/model-personalization/muscle-tendon-personalization/");
     }
 
     @Override

--- a/Gui/opensim/rice_cnl/src/org/opensim/rcnl/MTPPersonalizationToolModel.java
+++ b/Gui/opensim/rice_cnl/src/org/opensim/rcnl/MTPPersonalizationToolModel.java
@@ -140,7 +140,13 @@ public class MTPPersonalizationToolModel {
         return modelName;
     }
     public String getInputModelFile() {
-        return propInputModelFileString.getValue(0);
+        if (propInputModelFileString.size()==1)
+            return propInputModelFileString.getValue(0);
+        return "";
+    }
+
+    public void setInputModelFile(String newFileName) {
+        propInputModelFileString.setValue(newFileName);
     }
 
     /**

--- a/Gui/opensim/rice_cnl/src/org/opensim/rcnl/NCPPersonalizationJPanel.java
+++ b/Gui/opensim/rice_cnl/src/org/opensim/rcnl/NCPPersonalizationJPanel.java
@@ -27,6 +27,7 @@ import org.opensim.modeling.OpenSimObject;
 import org.opensim.modeling.PropertyObjectList;
 import org.opensim.utils.FileUtils;
 import org.opensim.view.pub.OpenSimDB;
+import org.opensim.utils.BrowserLauncher;
 
 /**
  *
@@ -606,6 +607,11 @@ public class NCPPersonalizationJPanel extends BaseToolPanel  implements Observer
         setSettingsFileDescription("Save Neural Control Personalization Settings file (xml)");
         jCheckBoxMTPInitialization.setSelected(ncpPersonalizationToolModel.getEnableInitialization());
         jSynergySetTextArea.setText(ncpPersonalizationToolModel.getSynergiesAsString());
+    }
+
+    @Override
+    public void goToHelpURL() {
+        BrowserLauncher.openURL("https://nmsm.rice.edu/model-personalization/neural-control-personalization/");
     }
 
     @Override

--- a/Gui/opensim/rice_cnl/src/org/opensim/rcnl/NCPPersonalizationJPanel.java
+++ b/Gui/opensim/rice_cnl/src/org/opensim/rcnl/NCPPersonalizationJPanel.java
@@ -611,7 +611,7 @@ public class NCPPersonalizationJPanel extends BaseToolPanel  implements Observer
 
     @Override
     public void goToHelpURL() {
-        BrowserLauncher.openURL("https://nmsm.rice.edu/model-personalization/neural-control-personalization/");
+        BrowserLauncher.openURL("https://nmsm.rice.edu/guides-and-publications/tool-overviews/model-personalization/neural-control-personalization/");
     }
 
     @Override

--- a/Gui/opensim/rice_cnl/src/org/opensim/rcnl/TreatmentOptimizationJPanel.java
+++ b/Gui/opensim/rice_cnl/src/org/opensim/rcnl/TreatmentOptimizationJPanel.java
@@ -27,6 +27,7 @@ import org.opensim.modeling.OpenSimObject;
 import org.opensim.modeling.PropertyObjectList;
 import org.opensim.utils.FileUtils;
 import org.opensim.view.pub.OpenSimDB;
+import org.opensim.utils.BrowserLauncher;
 
 /**
  *
@@ -1220,6 +1221,11 @@ public class TreatmentOptimizationJPanel extends BaseToolPanel  implements Obser
         treatmentOptimizationToolModel.setOCSettingsFile(optimalControlSolverSettingsFile);
         treatmentOptimizationToolModel.setSurrogateModelDir(surrogateModelDataDirectory);
    }
+
+   @Override
+    public void goToHelpURL() {
+        BrowserLauncher.openURL("https://nmsm.rice.edu/treatment-optimization/");
+    }
 
     @Override
     // void forceWritableProperties(OpenSimObject dObject) {

--- a/Gui/opensim/rice_cnl/src/org/opensim/rcnl/TreatmentOptimizationJPanel.java
+++ b/Gui/opensim/rice_cnl/src/org/opensim/rcnl/TreatmentOptimizationJPanel.java
@@ -1224,7 +1224,7 @@ public class TreatmentOptimizationJPanel extends BaseToolPanel  implements Obser
 
    @Override
     public void goToHelpURL() {
-        BrowserLauncher.openURL("https://nmsm.rice.edu/treatment-optimization/");
+        BrowserLauncher.openURL("https://nmsm.rice.edu/guides-and-publications/tool-overviews/treatment-optimization/");
     }
 
     @Override
@@ -1255,12 +1255,17 @@ public class TreatmentOptimizationJPanel extends BaseToolPanel  implements Obser
         dObject.updPropertyByName("states_coordinate_list").setValueIsDefault(false);
         dObject.updPropertyByName("optimal_control_solver_settings_file").setValueIsDefault(false);
         dObject.updPropertyByName("optimal_control_solver_settings_file").setValueIsDefault(false);
+        dObject.getPropertyByName("load_surrogate_model").setValueIsDefault(false);
+        dObject.getPropertyByName("save_surrogate_model").setValueIsDefault(false);
 
         AbstractProperty synergyController = dObject.getPropertyByName("RCNLSynergyController");
         OpenSimObject synergyControllerProperties = PropertyObjectList.getAs(synergyController).getValue(0);
         if (synergyControllerProperties.getPropertyByName("surrogate_model_data_directory").getValueIsDefault()){
             synergyController.setValueIsDefault(true);
         }
+        synergyControllerProperties.getPropertyByName("optimize_synergy_vectors").setValueIsDefault(false);
+        synergyControllerProperties.getPropertyByName("synergy_vector_normalization_method").setValueIsDefault(false);
+        synergyControllerProperties.getPropertyByName("synergy_vector_normalization_value").setValueIsDefault(false);
 
         AbstractProperty costTermSet = dObject.getPropertyByName("RCNLCostTermSet");
         costTermSet.setValueIsDefault(false);

--- a/Gui/opensim/rice_cnl/src/org/opensim/rcnl/TreatmentOptimizationJPanel.java
+++ b/Gui/opensim/rice_cnl/src/org/opensim/rcnl/TreatmentOptimizationJPanel.java
@@ -9,6 +9,8 @@ import java.awt.Dialog;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Observable;
 import java.util.Observer;
 import java.util.Vector;
@@ -1015,30 +1017,52 @@ public class TreatmentOptimizationJPanel extends BaseToolPanel  implements Obser
     @Override
     public void loadSettings(String nmsmFilename) {
         String fileName = BaseToolPanel.stripOuterTags(nmsmFilename);
+        String settingsFilePath = Paths.get(fileName).getParent().toString();
         Model model = OpenSimDB.getInstance().getCurrentModel();
         
-       //if(model==null) throw new IOException("JointPersonalizationJPanel got null model");
-       treatmentOptimizationToolModel = new TreatmentOptimizationToolModel(model, fileName);
-       currentModelFileTextField.setText(treatmentOptimizationToolModel.getInputModelFile());
-       osimxFilePath.setFileName(treatmentOptimizationToolModel.getInputOsimxFile());
-       InitialGuessDirPath.setFileName(treatmentOptimizationToolModel.getInitialGuessDir());
-       trackedQuantitiesDirPath.setFileName(treatmentOptimizationToolModel.getTrackedQuantitiesDir());
-       jTrialPrefixTextField.setText(treatmentOptimizationToolModel.getTrialPrefix());
-       outputDirPath.setFileName(treatmentOptimizationToolModel.getOutputResultDir());
-       solverSettingsFilePath.setFileName(treatmentOptimizationToolModel.getOCSettingsFile());
-       jCoordinateListTextArea1.setText(treatmentOptimizationToolModel.getPropCoordinateListString().toString());
-       
-       // Controllers tab
-       jOptimizeSynVecCheckBox.setSelected(treatmentOptimizationToolModel.getOptimizeSynergyVector());
-       jSynergyCoordinateListTextArea.setText(treatmentOptimizationToolModel.getRCNLSynergyCoordinateListString().toString());
-       surrogateModelDirPath.setFileName(treatmentOptimizationToolModel.getSurrogateModelDir());
-       jCoordinateListTorqueControllerTextArea.setText(treatmentOptimizationToolModel.getRCNLTorqueCoordinateListString().toString());
-       
-       // Cost+Constraints
-       costTermListModel = new CostTermListModel(treatmentOptimizationToolModel.getCostTermListAsObjectList());
-       jCostTermList.setModel(costTermListModel);
-       constraintTermListModel = new ConstraintTermListModel(treatmentOptimizationToolModel.getConstraintTermListAsObjectList());
-       jConstraintTermList.setModel(constraintTermListModel);
+        //if(model==null) throw new IOException("JointPersonalizationJPanel got null model");
+        treatmentOptimizationToolModel = new TreatmentOptimizationToolModel(model, fileName);
+
+        String resultsDirectory = treatmentOptimizationToolModel.getOutputResultDir();
+        String absoluteResultsDirectory = FileUtils.makePathAbsolute(resultsDirectory, settingsFilePath);
+        outputDirPath.setFileName(absoluteResultsDirectory);
+        
+        String initialGuessDirectory = treatmentOptimizationToolModel.getInitialGuessDir();
+        String absoluteInitialGuessDirectory = FileUtils.makePathAbsolute(initialGuessDirectory, settingsFilePath);
+        InitialGuessDirPath.setFileName(absoluteInitialGuessDirectory);
+
+        String trackedQuantitiesDirectory = treatmentOptimizationToolModel.getTrackedQuantitiesDir();
+        String absoluteTrackedQuantitiesDirectory = FileUtils.makePathAbsolute(trackedQuantitiesDirectory, settingsFilePath);
+        trackedQuantitiesDirPath.setFileName(absoluteTrackedQuantitiesDirectory);
+
+        String osimxFile = treatmentOptimizationToolModel.getInputOsimxFile();
+        String absoluteOsimxFile = FileUtils.makePathAbsolute(osimxFile, settingsFilePath);
+        osimxFilePath.setFileName(absoluteOsimxFile);
+
+        String solverSettingsFile = treatmentOptimizationToolModel.getOCSettingsFile();
+        String absoluteSolverSettingsFile = FileUtils.makePathAbsolute(solverSettingsFile, settingsFilePath);
+        solverSettingsFilePath.setFileName(absoluteSolverSettingsFile);
+
+        String surrogateModelDirectory = treatmentOptimizationToolModel.getSurrogateModelDir();
+        String absoluteSurrogateModelDirectory = FileUtils.makePathAbsolute(surrogateModelDirectory, settingsFilePath);
+        surrogateModelDirPath.setFileName(absoluteSurrogateModelDirectory);
+
+
+        currentModelFileTextField.setText(treatmentOptimizationToolModel.getInputModelFile());
+        jTrialPrefixTextField.setText(treatmentOptimizationToolModel.getTrialPrefix());
+        jCoordinateListTextArea1.setText(treatmentOptimizationToolModel.getPropCoordinateListString().toString());
+        
+        // Controllers tab
+        jOptimizeSynVecCheckBox.setSelected(treatmentOptimizationToolModel.getOptimizeSynergyVector());
+        jSynergyCoordinateListTextArea.setText(treatmentOptimizationToolModel.getRCNLSynergyCoordinateListString().toString());
+        surrogateModelDirPath.setFileName(treatmentOptimizationToolModel.getSurrogateModelDir());
+        jCoordinateListTorqueControllerTextArea.setText(treatmentOptimizationToolModel.getRCNLTorqueCoordinateListString().toString());
+        
+        // Cost+Constraints
+        costTermListModel = new CostTermListModel(treatmentOptimizationToolModel.getCostTermListAsObjectList());
+        jCostTermList.setModel(costTermListModel);
+        constraintTermListModel = new ConstraintTermListModel(treatmentOptimizationToolModel.getConstraintTermListAsObjectList());
+        jConstraintTermList.setModel(constraintTermListModel);
     }  
 
     @Override
@@ -1138,11 +1162,63 @@ public class TreatmentOptimizationJPanel extends BaseToolPanel  implements Obser
     }
     @Override
     public void saveSettings(String fileName) {
-         String fullFilename = FileUtils.addExtensionIfNeeded(fileName, ".xml");
+        String settingsFilePath = Paths.get(fileName).getParent().toString();
+
+        String resultsDirectory = treatmentOptimizationToolModel.getOutputResultDir();
+        String initialGuessDirectory = treatmentOptimizationToolModel.getInitialGuessDir();
+        String trackedQuantitiesDirectory = treatmentOptimizationToolModel.getTrackedQuantitiesDir();
+        String inputOsimxFile = treatmentOptimizationToolModel.getInputOsimxFile();
+        String optimalControlSolverSettingsFile = treatmentOptimizationToolModel.getOCSettingsFile();
+        String surrogateModelDataDirectory = treatmentOptimizationToolModel.getSurrogateModelDir();
+
+        Path resultsDirectoryPath = Paths.get(resultsDirectory);
+        String relativeResultsDir = FileUtils.makePathRelative(resultsDirectory, settingsFilePath);
+        if (relativeResultsDir != null && resultsDirectoryPath!=null && resultsDirectoryPath.isAbsolute()){
+            treatmentOptimizationToolModel.setOutputResultDir(relativeResultsDir);
+        }
+
+        Path initialGuessDirectoryPath = Paths.get(initialGuessDirectory);
+        String relativeInitialGuessDir = FileUtils.makePathRelative(initialGuessDirectory, settingsFilePath);
+        if (relativeInitialGuessDir != null && initialGuessDirectoryPath!=null && initialGuessDirectoryPath.isAbsolute()){
+            treatmentOptimizationToolModel.setInitialGuessDir(relativeInitialGuessDir);
+        }
+
+        Path trackedQuantitiesDirectoryPath = Paths.get(trackedQuantitiesDirectory);
+        String relativeTrackedQuantitiesDir = FileUtils.makePathRelative(trackedQuantitiesDirectory, settingsFilePath);
+        if (relativeTrackedQuantitiesDir != null && trackedQuantitiesDirectoryPath!=null && trackedQuantitiesDirectoryPath.isAbsolute()){
+            treatmentOptimizationToolModel.setTrackedQuantitiesDir(relativeTrackedQuantitiesDir);
+        }
+
+        Path inputOsimxFilePath = Paths.get(inputOsimxFile);
+        String relativeInputOsimxFile = FileUtils.makePathRelative(inputOsimxFile, settingsFilePath);
+        if (relativeInputOsimxFile != null && inputOsimxFilePath!=null && inputOsimxFilePath.isAbsolute()){
+            treatmentOptimizationToolModel.setInputOsimxFile(relativeInputOsimxFile);
+        }
+
+        Path optimalControlSolverSettingsFilePath = Paths.get(optimalControlSolverSettingsFile);
+        String relativeOptimalControlSolverSettingsFile = FileUtils.makePathRelative(optimalControlSolverSettingsFile, settingsFilePath);
+        if (relativeOptimalControlSolverSettingsFile != null && optimalControlSolverSettingsFilePath!=null && optimalControlSolverSettingsFilePath.isAbsolute()){
+            treatmentOptimizationToolModel.setOCSettingsFile(relativeOptimalControlSolverSettingsFile);
+        }
+
+        Path surrogateModelDataDirectoryPath = Paths.get(surrogateModelDataDirectory);
+        String relativeSurrogateModelDataDirectory = FileUtils.makePathRelative(surrogateModelDataDirectory, settingsFilePath);
+        if (relativeSurrogateModelDataDirectory != null && surrogateModelDataDirectoryPath!=null && surrogateModelDataDirectoryPath.isAbsolute()){
+            treatmentOptimizationToolModel.setSurrogateModelDir(relativeSurrogateModelDataDirectory);
+        }
+
+        String fullFilename = FileUtils.addExtensionIfNeeded(fileName, ".xml");
         OpenSimObject obj = treatmentOptimizationToolModel.getToolAsObject();
         forceWritableProperties(obj);
         obj.print(fullFilename);
         replaceOpenSimDocumentTags(fullFilename);
+
+        treatmentOptimizationToolModel.setOutputResultDir(resultsDirectory);
+        treatmentOptimizationToolModel.setInitialGuessDir(initialGuessDirectory);
+        treatmentOptimizationToolModel.setTrackedQuantitiesDir(trackedQuantitiesDirectory);
+        treatmentOptimizationToolModel.setInputOsimxFile(inputOsimxFile);
+        treatmentOptimizationToolModel.setOCSettingsFile(optimalControlSolverSettingsFile);
+        treatmentOptimizationToolModel.setSurrogateModelDir(surrogateModelDataDirectory);
    }
 
     @Override

--- a/Gui/opensim/rice_cnl/test/unit/src/project.properties
+++ b/Gui/opensim/rice_cnl/test/unit/src/project.properties
@@ -1,0 +1,2 @@
+javac.source=1.7
+javac.compilerargs=-Xlint -Xlint:-serial


### PR DESCRIPTION
The most complete implementation is in [MTPPersonalizationJPanel.java](https://github.com/aymanhab/opensim-gui-rcnl/compare/main...aymanhab:opensim-gui-rcnl:relative-paths?expand=1#diff-35849d48c2cad39bf68e5499031519578fc710036918bca3b57ce56fe44da91e) and [MTPPersonalizationToolModel.java](https://github.com/aymanhab/opensim-gui-rcnl/compare/main...aymanhab:opensim-gui-rcnl:relative-paths?expand=1#diff-6aa36eb9b46ce78dbd4cc139f1033f8e40ee97a820fca16879aca2d03f54607a)

It is implemented so that saving and loading settings files reads the path from the settings file name and makes all paths in the settings file relative to that. In loading, it does the reverse to convert back to absolute paths so that Opensim can read them. 

For the input model file, saving a settings file works as intended. When Ioad an existing settings file and try to save it, I get a null pointer exception at org.opensim.rcnl.MTPPersonalizationToolModel.setInputModelFile(MTPPersonalizationToolModel.java:149)