### PR TITLE
Remove duplicate names before presenting to selection dialog for both…

### DIFF
--- a/Gui/opensim/rice_cnl/src/org/opensim/rcnl/EditCosnstraintTermJPanel.java
+++ b/Gui/opensim/rice_cnl/src/org/opensim/rcnl/EditCosnstraintTermJPanel.java
@@ -7,6 +7,9 @@ package org.opensim.rcnl;
 
 import java.text.NumberFormat;
 import java.text.ParseException;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import org.openide.DialogDescriptor;
@@ -279,8 +282,9 @@ public class EditCosnstraintTermJPanel extends javax.swing.JPanel {
 
     private void editComonentListButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_editComonentListButtonActionPerformed
         // TODO add your handling code here:
-        String[] names = RCNLCostTermsInfo.getAvailableNamesForComponentType(constraintTermModel.getComponentType(), constraintTermModel.getModel(), 
+        String[] allNames = RCNLCostTermsInfo.getAvailableNamesForComponentType(constraintTermModel.getComponentType(), constraintTermModel.getModel(), 
                 this.trackedDataDir, this.initialGuessDir, this.osimxFile);
+        String[] names = removeDuplicates(allNames);
         if (names.length == 0 && !constraintTermModel.getComponentType().equalsIgnoreCase("none")){
             NotifyDescriptor.Message dlg =
                           new NotifyDescriptor.Message("Error populating list of options, please check model, tracked data and initial guess directories.");
@@ -364,6 +368,11 @@ public class EditCosnstraintTermJPanel extends javax.swing.JPanel {
         jMinErrorTextFieldActionPerformed(null);
     }//GEN-LAST:event_jMinErrorTextFieldFocusLost
 
+    private String[] removeDuplicates(String[] input) {
+        if (input == null) return null;
+        Set<String> set = new LinkedHashSet<>(Arrays.asList(input));
+        return set.toArray(new String[0]);
+    }
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton editComonentListButton;

--- a/Gui/opensim/rice_cnl/src/org/opensim/rcnl/EditCostTermJPanel.java
+++ b/Gui/opensim/rice_cnl/src/org/opensim/rcnl/EditCostTermJPanel.java
@@ -8,6 +8,9 @@ package org.opensim.rcnl;
 import java.awt.Dialog;
 import java.text.NumberFormat;
 import java.text.ParseException;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.Vector;
 import javax.swing.ListSelectionModel;
 import javax.swing.event.ListSelectionEvent;
@@ -286,8 +289,9 @@ public class EditCostTermJPanel extends javax.swing.JPanel {
     private void editComonentListButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_editComonentListButtonActionPerformed
         // TODO add your handling code here:
         // get Component list from costTermModel as well as the corresponding property
-        String[] names = RCNLCostTermsInfo.getAvailableNamesForComponentType(costTermModel.getComponentType(), costTermModel.getModel(), 
+        String[] allNames = RCNLCostTermsInfo.getAvailableNamesForComponentType(costTermModel.getComponentType(), costTermModel.getModel(), 
                 this.trackedDataDir, this.initialGuessDir, this.osimxFile);
+        String[] names = removeDuplicates(allNames);
         if (names.length == 0 && !costTermModel.getComponentType().equalsIgnoreCase("none")){
              NotifyDescriptor.Message dlg =
                           new NotifyDescriptor.Message("Error populating list of options, please check model, tracked data and initial guess directories.");
@@ -373,6 +377,12 @@ public class EditCostTermJPanel extends javax.swing.JPanel {
         // TODO add your handling code here:
         jErrorCenterTextFieldActionPerformed(null);
     }//GEN-LAST:event_jErrorCenterTextFieldFocusLost
+
+    private String[] removeDuplicates(String[] input) {
+        if (input == null) return null;
+        Set<String> set = new LinkedHashSet<>(Arrays.asList(input));
+        return set.toArray(new String[0]);
+    }
 
 
     // Variables declaration - do not modify//GEN-BEGIN:variables


### PR DESCRIPTION
… Cost and Constraint terms

Fixes issue #65 

### Brief summary of changes
Before presenting names to filtering dialog, remove duplicates (both CostTerm and ConstraintTerm).

### Testing I've completed
Tested the zip file sent by @RobSalati and no duplicates were shown 

### CHANGELOG.md (choose one)

- Don't know if/where we keep track of these changes
